### PR TITLE
The shell script doesn't work with paths that have spaces

### DIFF
--- a/pspdev-docker.sh
+++ b/pspdev-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ ! -z "$*" ]; then
-  docker run -v `pwd`:/build pspdev-docker $*
+  docker run -v "`pwd`:/build" pspdev-docker $*
 fi


### PR DESCRIPTION
We fix this by encapsulating the path in quotes