### PR TITLE
Don't use dash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV PATH ${PATH}:${PSPDEV}/bin
 RUN \
   apt-get -y update && \
   apt-get -y install autoconf automake bison cmake doxygen flex g++ gcc git libelf-dev libgmp-dev libmpfr-dev libncurses5-dev libreadline-dev libsdl1.2-dev libtool-bin libusb-dev make mpc patch subversion tcl texinfo unzip wget && \
+  echo "dash dash/sh boolean false" | debconf-set-selections && \
+  dpkg-reconfigure --frontend=noninteractive dash && \
   apt-get -y clean autoclean autoremove && \
   rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
This PR fix a warning appearing at the very beginning of the build :

```
Cloning into 'psptoolchain'...
/build/psptoolchain /build
--------------------------------------------------------------------------------
ERROR: /bin/sh is a symlink to dash!

This does not go well with libtool, and will make compilation of some packages
from psplibraries fail to compile.

On Debian-derived distros (including Ubuntu), the following will disable dash,
and make /bin/sh fall back to bash:

$ echo "dash dash/sh boolean false"|sudo debconf-set-selections
$ sudo dpkg-reconfigure --frontend=noninteractive dash

Replace 'boolean false' with 'boolean true' if you want to go back to dash.

The reason why dash is the default on some systems is that letting bash provide
/bin/sh makes all shell scripts start up slightly slower.
--------------------------------------------------------------------------------
```

Indeed some packages fail to compile with `dash` (ex: libpng, openal, pixman, and others). So this commit does what the warning asks and that fixes lot of issues. Note that with this fix, there are still errors with SDL_Image and SDL_ttf. I'm going to make an other PR on pspdev/psplibraries and/or pspdev/psp-ports for these issues.