### PR TITLE
Don't install libsdl1.2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH ${PATH}:${PSPDEV}/bin
 
 RUN \
   apt-get -y update && \
-  apt-get -y install autoconf automake bison cmake doxygen flex g++ gcc git libelf-dev libgmp-dev libmpfr-dev libncurses5-dev libreadline-dev libsdl1.2-dev libtool-bin libusb-dev make mpc patch subversion tcl texinfo unzip wget && \
+  apt-get -y install autoconf automake bison cmake doxygen flex g++ gcc git libelf-dev libgmp-dev libmpfr-dev libncurses5-dev libreadline-dev libtool-bin libusb-dev make mpc patch subversion tcl texinfo unzip wget && \
   apt-get -y clean autoclean autoremove && \
   rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
This package is only needed because there is a bug in the SDL_gfx build script in the psplibraries repository. This is addressed in https://github.com/pspdev/psplibraries/pull/43. When that PR has been merged, the entire psptoolchain can build without  libsdl1.2-dev installed. No including it should shave at least 100 megabytes, probably more, off of the docker container.