### PR TITLE
Only use sudo when needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH ${PATH}:${PSPDEV}/bin
 
 RUN \
   apt-get -y update && \
-  apt-get -y install autoconf automake bison cmake doxygen flex g++ gcc git libelf-dev libgmp-dev libmpfr-dev libncurses5-dev libreadline-dev libtool-bin libusb-dev make mpc patch subversion tcl texinfo unzip wget && \
+  apt-get -y install autoconf automake bison cmake doxygen flex g++ gcc git graphviz libelf-dev libgmp-dev libmpfr-dev libncurses5-dev libreadline-dev libtool-bin libusb-dev make mpc patch subversion tcl texinfo unzip wget && \
   apt-get -y clean autoclean autoremove && \
   rm -rf /var/lib/{apt,dpkg,cache,log}/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH ${PATH}:${PSPDEV}/bin
 
 RUN \
   apt-get -y update && \
-  apt-get -y install autoconf automake bison cmake doxygen flex g++ gcc git graphviz libelf-dev libgmp-dev libmpfr-dev libncurses5-dev libreadline-dev libtool-bin libusb-dev make mpc patch subversion tcl texinfo unzip wget && \
+  apt-get -y install autoconf automake bison cmake doxygen flex g++ gcc git libelf-dev libgmp-dev libmpfr-dev libncurses5-dev libreadline-dev libtool-bin libusb-dev make mpc patch subversion tcl texinfo unzip wget && \
   apt-get -y clean autoclean autoremove && \
   rm -rf /var/lib/{apt,dpkg,cache,log}/
 

--- a/pspdev-docker
+++ b/pspdev-docker
@@ -3,7 +3,7 @@
 IMAGE="pspdev-docker"
 
 if [ "$(uname)" == "Linux" ] && [ -z "$(id|grep docker)" ] && [ "$EUID" -ne 0 ];then
-	sudo $0 "$@"
+	sudo "$0" "$@"
 	exit $?
 fi
 if [ ! -z "$*" ]; then

--- a/pspdev-docker
+++ b/pspdev-docker
@@ -2,10 +2,13 @@
 
 IMAGE="pspdev-docker"
 
+# Rerun script with sudo if the current user is not allowed to run docker
 if [ "$(uname)" == "Linux" ] && [ -z "$(id|grep docker)" ] && [ "$EUID" -ne 0 ];then
 	sudo "$0" "$@"
 	exit $?
 fi
+
+# Give a shell or run a command depending on input
 if [ ! -z "$*" ]; then
   docker run -v "`pwd`:/build" --rm ${IMAGE} $*
 else

--- a/pspdev-docker
+++ b/pspdev-docker
@@ -2,7 +2,7 @@
 
 IMAGE="pspdev-docker"
 
-if [ "$EUID" -ne 0 ] && [ -z "$(id|grep docker)" ];then
+if [ "$(uname)" == "Linux" ] && [ -z "$(id|grep docker)" ] && [ "$EUID" -ne 0 ];then
 	sudo $0 "$@"
 	exit $?
 fi

--- a/pspdev-docker
+++ b/pspdev-docker
@@ -6,5 +6,8 @@ if [ "$EUID" -ne 0 ] && [ -z "$(id|grep docker)" ];then
 	sudo $0 "$@"
 	exit $?
 fi
-
-docker run -v "`pwd`:/build" --rm ${IMAGE} $*
+if [ ! -z "$*" ]; then
+  docker run -v "`pwd`:/build" --rm ${IMAGE} $*
+else
+  docker run -v "`pwd`:/build" --rm -it ${IMAGE} bash
+fi

--- a/pspdev-docker
+++ b/pspdev-docker
@@ -4,6 +4,7 @@ IMAGE="pspdev-docker"
 
 if [ "$EUID" -ne 0 ] && [ -z "$(id|grep docker)" ];then
 	sudo $0 "$@"
+	exit $?
 fi
 
 docker run -v "`pwd`:/build" --rm ${IMAGE} $*

--- a/pspdev-docker
+++ b/pspdev-docker
@@ -2,8 +2,8 @@
 
 IMAGE="pspdev-docker"
 
-if [ ! -z "$*" ]; then
-  sudo docker run -v "`pwd`:/build" --rm ${IMAGE} $*
-else
-  sudo docker run -v "`pwd`:/build" --rm -it ${IMAGE} bash
+if [ "$EUID" -ne 0 ] && [ -z "$(id|grep docker)" ];then
+	sudo $0 "$@"
 fi
+
+docker run -v "`pwd`:/build" --rm ${IMAGE} $*


### PR DESCRIPTION
Currently sudo is always used in the script, which is a bit annoying. With this change it checks if your user is in the docker group before trying to use sudo, since users in the docker group do not require sudo for running docker.