### PR TITLE
Add missing dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ RUN \
 
 SHELL ["/bin/bash", "-c"]
 
+# FIX: could not open file: /etc/mtab: No such file or directory on /scripts/003-psp-packages.sh
+RUN ln -sf /proc/mounts /etc/mtab
+
 RUN \
-  git clone https://github.com/pspdev/psptoolchain.git && \
-  pushd psptoolchain && \
-    ./toolchain.sh && \
+  git clone https://github.com/pspdev/pspdev.git && \
+  pushd pspdev && \
+    ./build-all.sh && \
     popd && \
-  rm -Rf psptoolchain
+  rm -Rf pspdev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
-MAINTAINER Naomi Peori <naomi@peori.ca>
+LABEL maintainer="Naomi Peori <naomi@peori.ca>"
 
 WORKDIR /build
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -9,7 +9,7 @@ ENV PATH ${PATH}:${PSPDEV}/bin
 
 RUN \
   apt-get -y update && \
-  apt-get -y install autoconf automake bison bzip2 cmake doxygen flex g++ gcc git gzip libarchive-dev libcurl4-openssl-dev libelf-dev libgpgme-dev libncurses5-dev libreadline-dev libssl-dev libtool-bin libusb-dev m4 make patch pkg-config python3 python3-venv subversion tar tcl texinfo unzip wget xz-utils && \
+  apt-get -y install autoconf automake bison bzip2 cmake curl doxygen fakeroot flex g++ gcc git gzip libarchive-dev libarchive-tools libcurl4 libcurl4-openssl-dev libelf-dev libgmp3-dev libgpgme-dev libmpc-dev libmpfr-dev libncurses5-dev libreadline-dev libssl-dev libtool-bin libusb-dev m4 make patch pkg-config python3 python3-pip python3-venv subversion sudo tar tcl texinfo unzip wget xz-utils && \
   apt-get -y clean autoclean autoremove && \
   rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
## Purpose
Hello @ooPo and rest of pspdev team 👋 

This PR:
- Fixes the failing docker builds;
- Updates deprecated `MAINTAINER` tag in the dockerfile (see [this doc](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)).
- Use [pspdev](https://github.com/pspdev/pspdev) instead of [psptoolchain](https://github.com/pspdev/psptoolchain) (following PR  https://github.com/pspdev/psptoolchain/pull/160 )

## Notes

When building the dockerfile locally (e.g. running ``), I was getting the following error:

```
Cloning into 'psptoolchain'...
/build/psptoolchain /build
Couldn't find dependencies:
  - pip3
../depends/check-dependencies.sh: Failed.
The command '/bin/bash -c git clone https://github.com/pspdev/psptoolchain.git &&   pushd psptoolchain &&     ./toolchain.sh &&     popd &&   rm -Rf psptoolchain' returned a non-zero code: 1
```

I noticed the latest Github actions were also failing ([example](https://github.com/pspdev/pspdev-docker/runs/4557773234?check_suite_focus=true#step:4:1428)).

After adding `python3-pip` dependency, the build would fail with errors like `Missing GMP ...` stuff, so I compared the dependencies of the current `Dockerfile` with the ones on [prepare-debian-ubuntu.sh](https://github.com/pspdev/psptoolchain/blob/master/prepare-debian-ubuntu.sh) file of [psptoolchain](https://github.com/pspdev/psptoolchain), and indeed there were some missing:
![dependencies_from_psptoolchain](https://user-images.githubusercontent.com/11976836/153681094-56c4f60b-b297-4bc1-90ca-f515a90b7757.png)

